### PR TITLE
Add interact with protocol directly option to pooled stacking

### DIFF
--- a/src/pages/choose-stacking-method/components/pooled-stacking-card.tsx
+++ b/src/pages/choose-stacking-method/components/pooled-stacking-card.tsx
@@ -1,5 +1,6 @@
 import { Box, Flex } from '@stacks/ui';
 import { IconStairs } from '@tabler/icons-react';
+import { IconLock } from '@tabler/icons-react';
 
 import divingBoardIllustration from '@assets/images/stack-in-a-pool.svg';
 import { Users } from '@components/icons/users';
@@ -32,11 +33,9 @@ export function PooledStackingCard(props: ChooseStackingMethodLayoutProps) {
       </Description>
 
       <OptionBenefitContainer>
+        <OptionBenefit icon={IconLock}>Interact with the protocol directly</OptionBenefit>
         <OptionBenefit icon={Users}>A pool stacks on your behalf</OptionBenefit>
         <OptionBenefit icon={IconStairs}>No minimum required</OptionBenefit>
-
-        {/* This is just a hack to get the correct allignment for the CTA button */}
-        <OptionBenefit icon={() => null}>&nbsp;</OptionBenefit>
       </OptionBenefitContainer>
 
       <Flex alignItems="center">


### PR DESCRIPTION
This PR
* adds the benefit options of "IInteract with the protocol directly" to pooled stacking
* fixes #52 

![image](https://user-images.githubusercontent.com/1449049/228458536-9396bc14-86b8-4495-a162-eef3c24451e5.png)
