### PR TITLE
Use correct formatting for btc address

### DIFF
--- a/src/utils/stacking.ts
+++ b/src/utils/stacking.ts
@@ -1,24 +1,6 @@
-import { sha256 } from '@noble/hashes/sha256';
-import { base58check } from '@scure/base';
 import { poxAddressToBtcAddress } from '@stacks/stacking';
-import { AddressHashMode } from '@stacks/transactions';
-import BN from 'bn.js';
-import { Buffer } from 'buffer';
 
 import { NETWORK } from '@constants/app';
-
-// TODO: Can't figure out the right types
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const poxKeyToVersionBytesMap: Record<'mainnet' | 'testnet', any> = {
-  mainnet: {
-    [AddressHashMode.SerializeP2PKH]: 0x00,
-    [AddressHashMode.SerializeP2SH]: 0x05,
-  },
-  testnet: {
-    [AddressHashMode.SerializeP2PKH]: 0x6f,
-    [AddressHashMode.SerializeP2SH]: 0xc4,
-  },
-};
 
 interface ConvertToPoxAddressBtc {
   version: Uint8Array;

--- a/src/utils/stacking.ts
+++ b/src/utils/stacking.ts
@@ -1,5 +1,6 @@
 import { sha256 } from '@noble/hashes/sha256';
 import { base58check } from '@scure/base';
+import { poxAddressToBtcAddress } from '@stacks/stacking';
 import { AddressHashMode } from '@stacks/transactions';
 import BN from 'bn.js';
 import { Buffer } from 'buffer';
@@ -25,12 +26,7 @@ interface ConvertToPoxAddressBtc {
 }
 export function convertPoxAddressToBtc(network: 'mainnet' | 'testnet') {
   return ({ version, hashbytes }: ConvertToPoxAddressBtc) => {
-    const ver = new BN(version).toNumber() as AddressHashMode;
-    /* if (ver === AddressHashMode.SerializeP2WPKH || ver === AddressHashMode.SerializeP2WSH) */
-    /*   return null; */
-    return base58check(sha256).encode(
-      Buffer.concat([Buffer.from([poxKeyToVersionBytesMap[network][ver]]), hashbytes])
-    );
+    return poxAddressToBtcAddress(version[0], hashbytes, network);
   };
 }
 


### PR DESCRIPTION
This PR
* uses the formatting function from @stacks/stacking that supports also segwit addresses, etc
* fixes #82 