### PR TITLE
Use origin for icon url

### DIFF
--- a/src/components/auth-provider/auth-provider.tsx
+++ b/src/components/auth-provider/auth-provider.tsx
@@ -60,7 +60,7 @@ export function AuthProvider({ children }: Props) {
       userSession,
       appDetails: {
         name: 'Stacking',
-        icon: 'https://stacking.live/logo.svg',
+        icon: `${window.location.origin}/logo.svg`,
       },
       onFinish() {
         setIsSigningIn(false);


### PR DESCRIPTION
This PR
* change the url of app icon for auth to the origin/logo.svg of the app
* fixes #85 