### PR TITLE
Hide reward address section in start-pooled-stacking

### DIFF
--- a/src/pages/stacking/components/stacking-form-container.tsx
+++ b/src/pages/stacking/components/stacking-form-container.tsx
@@ -10,7 +10,7 @@ interface ChildProps extends BoxProps {
   step: number;
 }
 
-type TChild = React.ReactElement<ChildProps>;
+type TChild = React.ReactElement<ChildProps> | null;
 
 interface Props {
   children: TChild | TChild[];

--- a/src/pages/stacking/start-pooled-stacking/start-pooled-stacking.tsx
+++ b/src/pages/stacking/start-pooled-stacking/start-pooled-stacking.tsx
@@ -26,7 +26,6 @@ import { ChoosePoolingRewardAddress } from './components/choose-pooling-reward-a
 import { ConfirmAndSubmit } from './components/confirm-and-pool';
 import { PoolingInfoCard } from './components/delegated-stacking-info-card';
 import { PooledStackingIntro } from './components/pooled-stacking-intro';
-import { PresetPoolingRewardAddressInfo } from './components/preset-pooling-reward-address-info';
 import { pools } from './components/preset-pools';
 import { EditingFormValues, PoolWrapperAllowanceState } from './types';
 import {

--- a/src/pages/stacking/start-pooled-stacking/start-pooled-stacking.tsx
+++ b/src/pages/stacking/start-pooled-stacking/start-pooled-stacking.tsx
@@ -204,9 +204,7 @@ function StartPooledStackingLayout({
                     btcAddress={currentAccountAddresses.btcAddressP2wpkh || ''}
                     editable={rewardAddressEditable || !currentAccountAddresses.btcAddressP2wpkh}
                   />
-                ) : (
-                  <PresetPoolingRewardAddressInfo />
-                )}
+                ) : null}
                 <ChoosePoolingAmount />
                 <ChoosePoolingDuration />
                 <ConfirmAndSubmit


### PR DESCRIPTION
This PR 
* allows null elements in stacking form container
* removes the reward address session
* fixes #58 
* fixes #44 